### PR TITLE
Add Firebase messaging support

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View, SafeAreaView, ScrollView, ActivityIndicator } from 'react-native';
+import { StyleSheet, Text, View, SafeAreaView, ScrollView, ActivityIndicator, Alert } from 'react-native';
 import { NavigationContainer, DefaultTheme, useNavigationContainerRef } from "@react-navigation/native";
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import HomeScreen from './screens/HomeScreen';
@@ -55,6 +55,22 @@ export default function App() {
     };
 
     checkLoginStatus();
+    requestUserPermission();
+
+    messaging()
+      .getToken()
+      .then(token => {
+        console.log('FCM Token:', token);
+      });
+
+    const unsubscribe = messaging().onMessage(async remoteMessage => {
+      const { notification } = remoteMessage;
+      if (notification) {
+        Alert.alert(notification.title || 'New Message', notification.body || '');
+      }
+    });
+
+    return unsubscribe;
   }, []);
 
   if (loading) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
 import { registerRootComponent } from 'expo';
+import '@react-native-firebase/app';
+import messaging from '@react-native-firebase/messaging';
 
 import App from './App';
+
+messaging().setBackgroundMessageHandler(async remoteMessage => {
+  console.log('Message handled in the background!', remoteMessage);
+});
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,


### PR DESCRIPTION
## Summary
- request user permission for notifications
- log FCM token and show foreground notifications
- handle background messages
- ensure Firebase app module loads on startup

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685d757f68a083269d58888aaaaad343