### PR TITLE
Add bottom tab navigation

### DIFF
--- a/App.js
+++ b/App.js
@@ -2,6 +2,8 @@ import { StatusBar } from 'expo-status-bar';
 import { StyleSheet, Text, View, SafeAreaView, ScrollView, ActivityIndicator, Alert } from 'react-native';
 import { NavigationContainer, DefaultTheme, useNavigationContainerRef } from "@react-navigation/native";
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Ionicons } from '@expo/vector-icons';
 import HomeScreen from './screens/HomeScreen';
 import Dashboard from './screens/Dashboard';
 import Header from './components/Header';
@@ -21,6 +23,7 @@ import MarksLists from './screens/MarksList';
 
 
 const Stack = createNativeStackNavigator();
+const Tab = createBottomTabNavigator();
 
 export default function App() {
   // Get AsyncStorage
@@ -43,6 +46,76 @@ export default function App() {
 
     checkLoginStatus();
   }, []);
+
+  const MainTabs = () => (
+    <Tab.Navigator
+      screenOptions={({ route }) => ({
+        tabBarIcon: ({ color, size }) => {
+          let iconName;
+          if (route.name === 'Home') {
+            iconName = 'home';
+          } else if (route.name === 'Attendance') {
+            iconName = 'calendar';
+          } else if (route.name === 'Marks') {
+            iconName = 'clipboard';
+          } else if (route.name === 'Profile') {
+            iconName = 'person';
+          }
+          return <Ionicons name={iconName} size={size} color={color} />;
+        },
+        tabBarActiveTintColor: '#6C63FF',
+        tabBarInactiveTintColor: 'gray',
+      })}
+    >
+      <Tab.Screen
+        name="Home"
+        options={{ header: () => <Header /> }}
+      >
+        {props => (
+          <SafeAreaView style={{ flex: 1 }}>
+            <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
+              <HomeScreen {...props} setValue={setValue} />
+            </ScrollView>
+          </SafeAreaView>
+        )}
+      </Tab.Screen>
+      <Tab.Screen
+        name="Attendance"
+        component={Attendance}
+        options={{
+          title: 'Attendance',
+          headerStyle: { backgroundColor: '#eee' },
+          headerTintColor: '#111',
+          headerTextAlign: 'center',
+        }}
+      />
+      <Tab.Screen
+        name="Marks"
+        component={Marks}
+        options={{
+          title: 'Marks',
+          headerStyle: { backgroundColor: '#eee' },
+          headerTintColor: '#111',
+          headerTextAlign: 'center',
+        }}
+      />
+      <Tab.Screen
+        name="Profile"
+        options={{
+          title: 'Profile',
+          headerStyle: { backgroundColor: '#eee' },
+          headerTintColor: '#111',
+          headerTextAlign: 'center',
+        }}
+      >
+        {props => (
+          <SafeAreaView style={{ flex: 1 }}>
+            <Profile setValue={setValue} />
+          </SafeAreaView>
+        )}
+      </Tab.Screen>
+    </Tab.Navigator>
+  );
 
   if (loading) {
     return (
@@ -77,47 +150,16 @@ export default function App() {
           ) : (
             <>
               <Stack.Screen
-                name="Home"
-                options={{
-                  header: () => <Header />,
-                }}
+                name="Main"
+                options={{ headerShown: false }}
               >
-                {(props) => (
-                  <SafeAreaView style={{ flex: 1 }}>
-                    <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
-                      <HomeScreen {...props} setValue={setValue} />
-                    </ScrollView>
-                  </SafeAreaView>
-                )}
+                {() => <MainTabs />}
               </Stack.Screen>
-
-              <Stack.Screen
-                name="Attendance"
-                component={Attendance}
-                options={{
-                  title: 'Attendance',
-                  headerStyle: { backgroundColor: '#eee' },
-                  headerTintColor: '#111',
-                  headerTextAlign: 'center',
-                  detachPreviousScreen: false,
-                }}
-              />
               <Stack.Screen
                 name="TakeAttendance"
                 component={TakeAttendance}
                 options={{
                   title: 'Attendance',
-                  headerStyle: { backgroundColor: '#eee' },
-                  headerTintColor: '#111',
-                  headerTextAlign: 'center',
-                  detachPreviousScreen: false,
-                }}
-              />
-              <Stack.Screen
-                name="Marks"
-                component={Marks}
-                options={{
-                  title: 'Marks',
                   headerStyle: { backgroundColor: '#eee' },
                   headerTintColor: '#111',
                   headerTextAlign: 'center',
@@ -191,32 +233,7 @@ export default function App() {
                   detachPreviousScreen: false,
                 }}
               />
-              {/* <Stack.Screen
-                name="Profile"
-                component={Profile}
-                options={{
-                  title: 'Profile',
-                  headerStyle: { backgroundColor: '#111' },
-                  headerTintColor: '#fff',
-                  headerTitleStyle: { fontWeight: 'bold' },
-                  headerTextAlign: 'center'
-                }}
-              /> */}
-              <Stack.Screen
-                name="Profile"
-                options={{
-                  title: 'Profile',
-                  headerStyle: { backgroundColor: '#eee' },
-                  headerTintColor: '#111',
-                  headerTextAlign: 'center'
-                }}
-              >
-                {(props) => (
-                  <SafeAreaView style={{ flex: 1 }}>
-                    <Profile setValue={setValue} />
-                  </SafeAreaView>
-                )}
-              </Stack.Screen>
+              {/* Profile screen handled in bottom tabs */}
             </>
           )
         }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@react-native-oh-tpl/react-native-marquee": "^0.5.0-0.0.1",
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/native-stack": "^7.2.0",
+    "@react-navigation/bottom-tabs": "^6.5.21",
     "axios": "^1.7.9",
     "dayjs": "^1.11.13",
     "expo": "~52.0.37",


### PR DESCRIPTION
## Summary
- add dependency for bottom tabs
- implement bottom tab navigator with Home, Attendance, Marks and Profile
- embed tab navigator in stack navigator as `Main`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d7abe1bcc8326b9b2b93f4726d787